### PR TITLE
Fix invalid get_time calls

### DIFF
--- a/adafruit_ntp.py
+++ b/adafruit_ntp.py
@@ -42,7 +42,7 @@ Implementation Notes
 import time
 import rtc
 
-__version__ = "1.0.0"
+__version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_NTP.git"
 
 class NTP:

--- a/adafruit_ntp.py
+++ b/adafruit_ntp.py
@@ -42,26 +42,31 @@ Implementation Notes
 import time
 import rtc
 
-__version__ = "0.0.0-auto.0"
+__version__ = "1.0.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_NTP.git"
 
 class NTP:
     """Network Time Protocol (NTP) helper module for CircuitPython.
     This module does not handle daylight savings or local time.
 
-    :param adafruit_esp32spi esp: ESP32SPI Module
+    :param adafruit_esp32spi esp: ESP32SPI object.
     """
     def __init__(self, esp):
         # Verify ESP32SPI module
         if "ESP_SPIcontrol" in str(type(esp)):
             self._esp = esp
         else:
-            raise TypeError("Provided esp is not an ESP_SPIcontrol object")
+            raise TypeError("Provided object is not an ESP_SPIcontrol object.")
+        self.valid_time = False
 
     def set_time(self):
         """Fetches and sets the microcontroller's current time
         in seconds since since Jan 1, 1970.
         """
-        now = self._esp.get_time()
-        now = time.localtime(now[0])
-        rtc.RTC().datetime = now
+        try:
+            now = self._esp.get_time()
+            now = time.localtime(now[0])
+            rtc.RTC().datetime = now
+            self.valid_time = True
+        except ValueError:
+            return

--- a/examples/ntp_simpletest.py
+++ b/examples/ntp_simpletest.py
@@ -30,7 +30,11 @@ while not esp.is_connected:
 ntp = NTP(esp)
 
 # Fetch and set the microcontroller's current UTC time
-ntp.set_time()
+# keep retrying until a valid time is returned
+while not ntp.valid_time:
+    ntp.set_time()
+    print("Failed to obtain time, retrying in 5 seconds...")
+    time.sleep(5)
 
 # Get the current time in seconds since Jan 1, 1970
 current_time = time.time()


### PR DESCRIPTION
Adding a `valid_time` property for `set_time` calls from user-code to detect error raised by ESP32SPI (https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/pull/73)

Addresses issue: https://github.com/adafruit/Adafruit_CircuitPython_NTP/issues/2

Tested on `Adafruit CircuitPython 4.1.0 on 2019-08-02; Adafruit Metro M4 Airlift Lite with samd51j19`
```
Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
Connecting to AP...
Failed to obtain time, retrying in 5 seconds...
Failed to obtain time, retrying in 5 seconds...
Seconds since Jan 1, 1970: 1569422698 seconds
struct_time(tm_year=2019, tm_mon=9, tm_mday=25, tm_hour=14, tm_min=44, tm_sec=58, tm_wday=2, tm_yday=268, tm_isdst=-1)
It is currently 9/25/2019 at 14:44:58 UTC
```