### PR TITLE
Add optional timezone offset for NTP.set_time()

### DIFF
--- a/adafruit_ntp.py
+++ b/adafruit_ntp.py
@@ -48,7 +48,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_NTP.git"
 
 class NTP:
     """Network Time Protocol (NTP) helper module for CircuitPython.
-    This module does not handle daylight savings time.
+    This module does not handle daylight savings or local time.
 
     :param adafruit_esp32spi esp: ESP32SPI object.
     """
@@ -63,15 +63,15 @@ class NTP:
 
     def set_time(self, tz_offset=0):
         """Fetches and sets the microcontroller's current time
-        in seconds since since Jan 1, 1970.  Optionally offsets
-        the current time to that of the requested timezone.
-        
-        :param int tz_offset: Timezone offset from GMT in hours
+        in seconds since since Jan 1, 1970.
+
+        :param int tz_offset: Timezone offset from GMT
         """
         try:
             now = self._esp.get_time()
-            now = time.localtime(now[0]+ (tz_offset * 3600))   # 3600 seconds in an hour
+            now = time.localtime(now[0] + (tz_offset * 3600))  # 3600 seconds in an hour
             rtc.RTC().datetime = now
             self.valid_time = True
-        except ValueError:
+        except ValueError as error:
+            print(str(error))
             return

--- a/adafruit_ntp.py
+++ b/adafruit_ntp.py
@@ -48,7 +48,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_NTP.git"
 
 class NTP:
     """Network Time Protocol (NTP) helper module for CircuitPython.
-    This module does not handle daylight savings or local time.
+    This module does not handle daylight savings time.
 
     :param adafruit_esp32spi esp: ESP32SPI object.
     """
@@ -61,13 +61,16 @@ class NTP:
             raise TypeError("Provided object is not an ESP_SPIcontrol object.")
         self.valid_time = False
 
-    def set_time(self):
+    def set_time(self, tz_offset=0):
         """Fetches and sets the microcontroller's current time
-        in seconds since since Jan 1, 1970.
+        in seconds since since Jan 1, 1970.  Optionally offsets
+        the current time to that of the requested timezone.
+        
+        :param int tz_offset: Timezone offset from GMT in hours
         """
         try:
             now = self._esp.get_time()
-            now = time.localtime(now[0])
+            now = time.localtime(now[0]+ (tz_offset * 3600))   # 3600 seconds in an hour
             rtc.RTC().datetime = now
             self.valid_time = True
         except ValueError:


### PR DESCRIPTION
Updated `NTP.set_time()` to accept an optional `tz_offset` which adjusts the recorded time by that number of hours.