### PR TITLE
Use UDP to talk to NTP servers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,43 +55,26 @@ Usage Example
 
 .. code-block:: python
 
+    import adafruit_ntp
+    import socketpool
     import time
-    import board
-    import busio
-    from digitalio import DigitalInOut
-    from adafruit_esp32spi import adafruit_esp32spi
-    from adafruit_ntp import NTP
+    import wifi
 
-    # If you are using a board with pre-defined ESP32 Pins:
-    esp32_cs = DigitalInOut(board.ESP_CS)
-    esp32_ready = DigitalInOut(board.ESP_BUSY)
-    esp32_reset = DigitalInOut(board.ESP_RESET)
+    # Get wifi details and more from a secrets.py file
+    try:
+        from secrets import secrets
+    except ImportError:
+        print("WiFi secrets are kept in secrets.py, please add them there!")
+        raise
 
-    # If you have an externally connected ESP32:
-    # esp32_cs = DigitalInOut(board.D9)
-    # esp32_ready = DigitalInOut(board.D10)
-    # esp32_reset = DigitalInOut(board.D5)
+    wifi.radio.connect(secrets["ssid"], secrets["password"])
 
-    spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-    esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+    pool = socketpool.SocketPool(wifi.radio)
+    ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
-    print("Connecting to AP...")
-    while not esp.is_connected:
-        try:
-            esp.connect_AP(b"WIFI_SSID", b"WIFI_PASS")
-        except RuntimeError as e:
-            print("could not connect to AP, retrying: ", e)
-            continue
-
-    # Initialize the NTP object
-    ntp = NTP(esp)
-
-    # Fetch and set the microcontroller's current UTC time
-    ntp.set_time()
-
-    # Get the current time in seconds since Jan 1, 1970
-    current_time = time.time()
-    print("Seconds since Jan 1, 1970: {} seconds".format(current_time))
+    while True:
+        print(ntp.datetime)
+        time.sleep(1)
 
 
 Documentation

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,8 +1,26 @@
 Simple test
 ------------
 
-Ensure your device works with this simple test.
+Ensure your device works with this simple test that prints out the time from NTP.
 
 .. literalinclude:: ../examples/ntp_simpletest.py
     :caption: examples/ntp_simpletest.py
+    :linenos:
+
+Set RTC
+------------
+
+Sync your CircuitPython board's realtime clock (RTC) with time from NTP.
+
+.. literalinclude:: ../examples/ntp_set_rtc.py
+    :caption: examples/ntp_set_rtc.py
+    :linenos:
+
+Simple test with CPython
+------------------------
+
+Test the library in CPython using ``socket``.
+
+.. literalinclude:: ../examples/ntp_cpython.py
+    :caption: examples/ntp_cpython.py
     :linenos:

--- a/examples/ntp_cpython.py
+++ b/examples/ntp_cpython.py
@@ -1,0 +1,15 @@
+"""Tests NTP with CPython socket"""
+
+# SPDX-FileCopyrightText: 2022 Scott Shawcroft for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+import adafruit_ntp
+import socket
+import time
+
+# Don't use tz_offset kwarg with CPython because it will adjust automatically.
+ntp = adafruit_ntp.NTP(socket)
+
+while True:
+    print(ntp.datetime)
+    time.sleep(1)

--- a/examples/ntp_cpython.py
+++ b/examples/ntp_cpython.py
@@ -1,11 +1,12 @@
-"""Tests NTP with CPython socket"""
-
 # SPDX-FileCopyrightText: 2022 Scott Shawcroft for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-import adafruit_ntp
+"""Tests NTP with CPython socket"""
+
 import socket
 import time
+
+import adafruit_ntp
 
 # Don't use tz_offset kwarg with CPython because it will adjust automatically.
 ntp = adafruit_ntp.NTP(socket)

--- a/examples/ntp_set_rtc.py
+++ b/examples/ntp_set_rtc.py
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: 2022 Scott Shawcroft for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-"""Print out time based on NTP."""
+"""Example demonstrating how to set the realtime clock (RTC) based on NTP time."""
 
 import adafruit_ntp
+import rtc
 import socketpool
 import time
 import wifi
@@ -20,7 +21,10 @@ wifi.radio.connect(secrets["ssid"], secrets["password"])
 pool = socketpool.SocketPool(wifi.radio)
 ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 
-while True:
-    print(ntp.datetime)
-    time.sleep(1)
+# NOTE: This changes the system time so make sure you aren't assuming that time
+# doesn't jump.
+rtc.RTC().datetime = ntp.datetime
 
+while True:
+    print(time.localtime())
+    time.sleep(1)

--- a/examples/ntp_set_rtc.py
+++ b/examples/ntp_set_rtc.py
@@ -3,11 +3,13 @@
 
 """Example demonstrating how to set the realtime clock (RTC) based on NTP time."""
 
-import adafruit_ntp
+import time
+
 import rtc
 import socketpool
-import time
 import wifi
+
+import adafruit_ntp
 
 # Get wifi details and more from a secrets.py file
 try:

--- a/examples/ntp_simpletest.py
+++ b/examples/ntp_simpletest.py
@@ -3,10 +3,12 @@
 
 """Print out time based on NTP."""
 
-import adafruit_ntp
-import socketpool
 import time
+
+import socketpool
 import wifi
+
+import adafruit_ntp
 
 # Get wifi details and more from a secrets.py file
 try:
@@ -23,4 +25,3 @@ ntp = adafruit_ntp.NTP(pool, tz_offset=0)
 while True:
     print(ntp.datetime)
     time.sleep(1)
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
 #
 # SPDX-License-Identifier: Unlicense
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,3 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-Adafruit-Blinka
-adafruit-circuitpython-esp32spi

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     name="adafruit-circuitpython-ntp",
     use_scm_version=True,
     setup_requires=["setuptools_scm"],
-    description="Network Time Protocol (NTP) helper for CircuitPython",
+    description="Network Time Protocol (NTP) helper for Python",
     long_description=long_description,
     long_description_content_type="text/x-rst",
     # The project's main homepage.
@@ -33,7 +33,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka", "adafruit-circuitpython-esp32spi"],
+    install_requires=[],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This completely redoes the library in favor of using a native
socket to fetch time from an NTP server.

Fixes #17 and fixes #16