### PR TITLE
Improve doc for ntp.datetime access behavior and exceptions

### DIFF
--- a/adafruit_ntp.py
+++ b/adafruit_ntp.py
@@ -67,7 +67,7 @@ class NTP:
 
     @property
     def datetime(self) -> time.struct_time:
-        ""Current time from NTP server. Accessing this property causes the NTP time request,
+        """Current time from NTP server. Accessing this property causes the NTP time request,
 unless there has already been a recent request. Raises OSError exception if no response
 is received within socket_timeout seconds"""
         if time.monotonic_ns() > self.next_sync:

--- a/adafruit_ntp.py
+++ b/adafruit_ntp.py
@@ -67,7 +67,9 @@ class NTP:
 
     @property
     def datetime(self) -> time.struct_time:
-        """Current time from NTP server."""
+        ""Current time from NTP server. Accessing this property causes the NTP time request,
+unless there has already been a recent request. Raises OSError exception if no response
+is received within socket_timeout seconds"""
         if time.monotonic_ns() > self.next_sync:
             self._packet[0] = 0b00100011  # Not leap second, NTP version 4, Client mode
             for i in range(1, len(self._packet)):

--- a/adafruit_ntp.py
+++ b/adafruit_ntp.py
@@ -68,8 +68,8 @@ class NTP:
     @property
     def datetime(self) -> time.struct_time:
         """Current time from NTP server. Accessing this property causes the NTP time request,
-unless there has already been a recent request. Raises OSError exception if no response
-is received within socket_timeout seconds"""
+        unless there has already been a recent request. Raises OSError exception if no response
+        is received within socket_timeout seconds"""
         if time.monotonic_ns() > self.next_sync:
             self._packet[0] = 0b00100011  # Not leap second, NTP version 4, Client mode
             for i in range(1, len(self._packet)):


### PR DESCRIPTION
Added some words to the inline documentation about both how 1) accesses to `ntp.datetime` actually cause the NTP request to be sent, and therefore 2) accesses to `ntp.datetime` may throw an `OSError` exception, which should be caught and handled appropriately