### PR TITLE
Example using adafruit_connection_manager

### DIFF
--- a/examples/ntp_connection_manager.py
+++ b/examples/ntp_connection_manager.py
@@ -9,6 +9,7 @@ import time
 import adafruit_connection_manager
 import adafruit_ntp
 
+# determine which radio is available
 try:
     import wifi
     import os

--- a/examples/ntp_connection_manager.py
+++ b/examples/ntp_connection_manager.py
@@ -1,0 +1,39 @@
+import time
+import adafruit_connection_manager
+import adafruit_ntp
+
+try:
+    import wifi
+    import os
+    # adjust method to get credentials as necessary...
+    wifi_ssid = os.getenv("CIRCUITPY_WIFI_SSID")
+    wifi_password = os.getenv("CIRCUITPY_WIFI_PASSWORD")
+    radio = wifi.radio
+    while not radio.connected:
+        radio.connect(wifi_ssid, wifi_password)
+except ImportError:
+    import board
+    from digitalio import DigitalInOut
+    spi = board.SPI()
+    try:
+        from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
+        # adjust pin for the specific board...
+        eth_cs = DigitalInOut(board.D10)
+        radio = WIZNET5K(spi, eth_cs)
+    except ImportError:
+        from adafruit_esp32spi.adafruit_esp32spi import ESP_SPIcontrol
+        # adjust pins for the specific board...
+        esp32_cs = DigitalInOut(board.ESP_CS)
+        esp32_ready = DigitalInOut(board.ESP_BUSY)
+        esp32_reset = DigitalInOut(board.ESP_RESET)
+        radio = ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
+# get the socket pool from connection manager
+socket = adafruit_connection_manager.get_radio_socketpool(radio)
+
+# adjust tz_offset for locale...
+ntp = adafruit_ntp.NTP(socket, tz_offset=-5)
+
+while True:
+    print(ntp.datetime)
+    time.sleep(5)

--- a/examples/ntp_connection_manager.py
+++ b/examples/ntp_connection_manager.py
@@ -1,3 +1,10 @@
+# SPDX-FileCopyrightText: 2024 Justin Myers for Adafruit Industries
+# SPDX-FileCopyrightText: 2024 anecdata for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+"""Print out time based on NTP."""
+
 import time
 import adafruit_connection_manager
 import adafruit_ntp

--- a/examples/ntp_connection_manager.py
+++ b/examples/ntp_connection_manager.py
@@ -23,6 +23,7 @@ except ImportError:
     import board
     from digitalio import DigitalInOut
 
+    # adjust with busio.SPI() as necessary...
     spi = board.SPI()
     try:
         from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K

--- a/examples/ntp_connection_manager.py
+++ b/examples/ntp_connection_manager.py
@@ -23,17 +23,13 @@ try:
 except ImportError:
     import board
     from digitalio import DigitalInOut
+    from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
 
     # adjust with busio.SPI() as necessary...
     spi = board.SPI()
-    try:
-        from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
-
-        # adjust pin for the specific board...
-        eth_cs = DigitalInOut(board.D10)
-        radio = WIZNET5K(spi, eth_cs)
-    except ImportError:
-        raise
+    # adjust pin for the specific board...
+    eth_cs = DigitalInOut(board.D10)
+    radio = WIZNET5K(spi, eth_cs)
 
 # get the socket pool from connection manager
 socket = adafruit_connection_manager.get_radio_socketpool(radio)

--- a/examples/ntp_connection_manager.py
+++ b/examples/ntp_connection_manager.py
@@ -33,13 +33,7 @@ except ImportError:
         eth_cs = DigitalInOut(board.D10)
         radio = WIZNET5K(spi, eth_cs)
     except ImportError:
-        from adafruit_esp32spi.adafruit_esp32spi import ESP_SPIcontrol
-
-        # adjust pins for the specific board...
-        esp32_cs = DigitalInOut(board.ESP_CS)
-        esp32_ready = DigitalInOut(board.ESP_BUSY)
-        esp32_reset = DigitalInOut(board.ESP_RESET)
-        radio = ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+        raise
 
 # get the socket pool from connection manager
 socket = adafruit_connection_manager.get_radio_socketpool(radio)

--- a/examples/ntp_connection_manager.py
+++ b/examples/ntp_connection_manager.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-"""Print out time based on NTP."""
+"""Print out time based on NTP, using connection manager"""
 
 import time
 import adafruit_connection_manager
@@ -12,6 +12,7 @@ import adafruit_ntp
 try:
     import wifi
     import os
+
     # adjust method to get credentials as necessary...
     wifi_ssid = os.getenv("CIRCUITPY_WIFI_SSID")
     wifi_password = os.getenv("CIRCUITPY_WIFI_PASSWORD")
@@ -21,14 +22,17 @@ try:
 except ImportError:
     import board
     from digitalio import DigitalInOut
+
     spi = board.SPI()
     try:
         from adafruit_wiznet5k.adafruit_wiznet5k import WIZNET5K
+
         # adjust pin for the specific board...
         eth_cs = DigitalInOut(board.D10)
         radio = WIZNET5K(spi, eth_cs)
     except ImportError:
         from adafruit_esp32spi.adafruit_esp32spi import ESP_SPIcontrol
+
         # adjust pins for the specific board...
         esp32_cs = DigitalInOut(board.ESP_CS)
         esp32_ready = DigitalInOut(board.ESP_BUSY)

--- a/examples/ntp_connection_manager.py
+++ b/examples/ntp_connection_manager.py
@@ -37,6 +37,4 @@ socket = adafruit_connection_manager.get_radio_socketpool(radio)
 # adjust tz_offset for locale...
 ntp = adafruit_ntp.NTP(socket, tz_offset=-5)
 
-while True:
-    print(ntp.datetime)
-    time.sleep(5)
+print(ntp.datetime)

--- a/examples/ntp_connection_manager.py
+++ b/examples/ntp_connection_manager.py
@@ -5,7 +5,6 @@
 
 """Print out time based on NTP, using connection manager"""
 
-import time
 import adafruit_connection_manager
 import adafruit_ntp
 


### PR DESCRIPTION
Example using adafruit_connection_manager to allow alternate radios (sources of sockets)

Addresses:
https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k/issues/132

Tested with CP9.0.0.* on:
Adafruit QY Py ESP32-S3
Raspberry Pi Pico W
MCU + Adafruit Ethernet FeatherWing

Tested on Adafruit PyPortal, but ESP32SPI currently has no context manager for sockets, and the NTP library requires this. ([issue](https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/issues/195) filed)