### PR TITLE
guard against invalid response

### DIFF
--- a/adafruit_ntp.py
+++ b/adafruit_ntp.py
@@ -102,6 +102,15 @@ class NTP:
             self.next_sync = destination + cache_offset * 1_000_000_000
             seconds = struct.unpack_from("!I", self._packet, offset=PACKET_SIZE - 8)[0]
 
+            # value should always be larger; giving a small buffer to handle jitter.
+            if (seconds + 5) < self._monotonic_start:
+                failed_offset = (self._monotonic_start - seconds) / 1_000_000_000
+                raise ArithmeticError(
+                    "need a time machine, ntp time is "
+                    + str(failed_offset)
+                    + "seconds in the past."
+                )
+
             self._monotonic_start = (
                 seconds
                 + self._tz_offset

--- a/adafruit_ntp.py
+++ b/adafruit_ntp.py
@@ -103,13 +103,8 @@ class NTP:
             seconds = struct.unpack_from("!I", self._packet, offset=PACKET_SIZE - 8)[0]
 
             # value should always be larger; giving a small buffer to handle jitter.
-            if (seconds + 5) < self._monotonic_start:
-                failed_offset = (self._monotonic_start - seconds) / 1_000_000_000
-                raise ArithmeticError(
-                    "need a time machine, ntp time is "
-                    + str(failed_offset)
-                    + "seconds in the past."
-                )
+            if seconds == 0:
+                raise ArithmeticError("ntp value is invalid (empty)")
 
             self._monotonic_start = (
                 seconds


### PR DESCRIPTION
Test to ensure response value is valid. Intermittent seconds=0 value have been seen.

fixes #35